### PR TITLE
fix!: replace oclif v1 dependency with oclif core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ package-lock.json
 node_modules
 coverage
 *.glksave
+.idea

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "author": "Twilio @twilio",
   "bugs": "https://github.com/twilio/twilio-cli/issues",
   "dependencies": {
-    "@oclif/command": "^1.7.0",
-    "@oclif/config": "^1.16.0",
-    "@oclif/test": "^1.2.6",
+    "@oclif/core": "^1.16.0",
+    "@oclif/test": "^2.1.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "nock": "^13.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const OclifConfig = require('@oclif/config');
+const { Config: OclifConfig } = require('@oclif/core');
 const { expect, test } = require('@oclif/test');
 const tmp = require('tmp');
 


### PR DESCRIPTION
- Migrate twilio cli test project from oclif v1 framework using @oclif/command, @oclif/config to oclif core (@oclif/core)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
